### PR TITLE
tf_gan_on_tpus.ipynb specify TensorFlow version 1.x, update kernel to python3, and correct link

### DIFF
--- a/tensorflow_gan/examples/colab_notebooks/tfgan_on_tpus.ipynb
+++ b/tensorflow_gan/examples/colab_notebooks/tfgan_on_tpus.ipynb
@@ -58,7 +58,7 @@
         "\n",
         "### CIFAR10 Task\n",
         "\n",
-        "In this colab we'll use TPUs to train a GAN for a more difficult task than the MNIST task tackled in the [GANEstimator](https://goto.google.com/tfgan-tutorial) colab. We'll use the [CIFAR10](https://wikipedia.org/wiki/CIFAR-10) dataset to train a model to generate images of airplanes, cars, birds, cats, deer, dogs, frogs, horses, ships, and trucks.\n",
+        "In this colab we'll use TPUs to train a GAN for a more difficult task than the MNIST task tackled in the [GANEstimator](https://github.com/tensorflow/gan/blob/master/tensorflow_gan/examples/colab_notebooks/tfgan_tutorial.ipynb) colab. We'll use the [CIFAR10](https://wikipedia.org/wiki/CIFAR-10) dataset to train a model to generate images of airplanes, cars, birds, cats, deer, dogs, frogs, horses, ships, and trucks.\n",
         "\n",
         "The training runs for 50000 steps and completes in roughly 10 minutes on TPUs.\n",
         "\n",
@@ -180,6 +180,8 @@
       ],
       "source": [
         "import os\n",
+        "#Specify tensorflow version 1.x be used\n",
+        "%tensorflow_version 1.x\n",
         "import tensorflow as tf\n",
         "import pprint\n",
         "assert 'COLAB_TPU_ADDR' in os.environ, 'Did you forget to switch to TPU?'\n",
@@ -1144,8 +1146,8 @@
       ]
     },
     "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
The tf_gan_on_tpus.ipynb colab notebook does not appear to be compatible with TensorFlow 2. 

Using tf.compact.v1... on depreciated functionality produces a "RuntimeError: Module must be applied in the graph it was instantiated for" error. 

I updated the kernel to python3 as python2 is no longer supported in colab. 

 The link to the GANEstimator notebook was switched to this notebook in Github. goto.google.com does not appear to be accessible to the public. 