### PR TITLE
Correct method

### DIFF
--- a/tensorflow_gan/examples/colab_notebooks/tfgan_tutorial.ipynb
+++ b/tensorflow_gan/examples/colab_notebooks/tfgan_tutorial.ipynb
@@ -176,7 +176,7 @@
         "  just_noise = (mode == tf.estimator.ModeKeys.PREDICT)\n",
         "  \n",
         "  noise_ds = (tf.data.Dataset.from_tensors(0).repeat()\n",
-        "              .map(lambda _: tf.random_normal([bs, nd])))\n",
+        "              .map(lambda _: tf.random.normal([bs, nd])))\n",
         "  \n",
         "  if just_noise:\n",
         "    return noise_ds\n",


### PR DESCRIPTION
As reported in issue #32 the method used is wrong.

Should be `tf.random.normal` instead of `tf.random_normal`.