### PR TITLE
Update MNIST Example Readme command

### DIFF
--- a/tensorflow_gan/examples/mnist/README.md
+++ b/tensorflow_gan/examples/mnist/README.md
@@ -9,7 +9,7 @@ Author: Joel Shor
 1.  Run:
 
     ```shell
-    python mnist/train.py --gan_type=[TYPE] --train_log_dir_mnist=/tmp/mnist
+    python mnist/train.py --gan_type=[TYPE] --train_log_dir=/tmp/mnist
     ```
 
     here `[TYPE]` can be is one of `unconditional`, `conditional` or `infogan`.


### PR DESCRIPTION
When I run the original command, I get this error:
```
$ python mnist/train.py --gan_type=conditional --train_log_dir_mnist=/tmp/mnist
WARNING:tensorflow:From /home/username/Code/gan_examples/gan/tensorflow_gan/python/estimator/tpu_gan_estimator.py:42: The name tf.estimator.tpu.TPUEstimator is deprecated. Please use tf.compat.v1.estimator.tpu.TPUEstimator instead.

WARNING:tensorflow:From /home/username/.asdf/installs/python/anaconda3-2020.07/lib/python3.8/site-packages/tensorflow/python/compat/v2_compat.py:96: disable_resource_variables (from tensorflow.python.ops.variable_scope) is deprecated and will be removed in a future version.
Instructions for updating:
non-resource variables are not supported in the long term
FATAL Flags parsing error: Unknown command line flag 'train_log_dir_mnist'. Did you mean: train_log_dir ?
Pass --helpshort or --helpfull to see help on flags.
```

And indeed, changing the command as recommended fixes that issue and gets me into the training loop.
```
$ python mnist/train.py --gan_type=conditional --train_log_dir=/tmp/mnist
WARNING:tensorflow:From /home/username/Code/gan_examples/gan/tensorflow_gan/python/estimator/tpu_gan_estimator.py:42: The name tf.estimator.tpu.TPUEstimator is deprecated. Please use tf.compat.v1.estimator.tpu.TPUEstimator instead.

WARNING:tensorflow:From /home/username/.asdf/installs/python/anaconda3-2020.07/lib/python3.8/site-packages/tensorflow/python/compat/v2_compat.py:96: disable_resource_variables (from tensorflow.python.ops.variable_scope) is deprecated and will be removed in a future version.
Instructions for updating:
non-resource variables are not supported in the long term
I1101 15:52:00.482490 140699447641856 dataset_builder.py:187] Load pre-computed datasetinfo (eg: splits) from bucket.
I1101 15:52:00.606416 140699447641856 dataset_info.py:410] Loading info from GCS for mnist/3.0.0
I1101 15:52:01.029893 140699447641856 dataset_builder.py:526] Dataset mnist is hosted on GCS. You can skip download_and_prepare by setting
data_dir=gs://tfds-data/datasets. If you find
that read performance is slow, copy the data locally with gsutil:
gsutil -m cp -R gs://tfds-data/datasets/mnist/3.0.0 /home/username/tensorflow_datasets/mnist

I1101 15:52:01.034518 140699447641856 dataset_builder.py:273] Generating dataset mnist (/home/username/tensorflow_datasets/mnist/3.0.0)
Downloading and preparing dataset mnist (11.06 MiB) to /home/username/tensorflow_datasets/mnist/3.0.0...
Dl Completed...: 0 url [00:00, ? url/s]          I1101 15:52:01.036628 140699447641856 download_manager.py:241] Downloading https://storage.googleapis.com/cvdf-datasets/mnist/train-images-idx3-ubyte.gz into /home/username/tensorflow_datasets/downloads/cvdf-datasets_mnist_train-images-idx3-ubyteJAsxAi0QnOBEygBw_XW2X7zp-LBZAIqqYSHN8ru4ZO4.gz.tmp.934a0c84bcab42248ac5454d23b3a2fa...
Dl Completed...:   0%|
...
```

Checking the directory in question shows that log files are being generated:
```
$ ls /tmp/mnist
checkpoint                                        model.ckpt-1797.data-00000-of-00001  model.ckpt-2185.data-00000-of-00001
events.out.tfevents.1604274746.computer-name  model.ckpt-1797.index                model.ckpt-2185.index
graph.pbtxt                                       model.ckpt-1797.meta                 model.ckpt-2185.meta
model.ckpt-1601.data-00000-of-00001               model.ckpt-1992.data-00000-of-00001  model.ckpt-2380.data-00000-of-00001
model.ckpt-1601.index                             model.ckpt-1992.index                model.ckpt-2380.index
model.ckpt-1601.meta                              model.ckpt-1992.meta                 model.ckpt-2380.meta
```