### PR TITLE
Updated relativistic losses for ESRGAN example

### DIFF
--- a/tensorflow_gan/examples/esrgan/losses.py
+++ b/tensorflow_gan/examples/esrgan/losses.py
@@ -13,7 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Loss functions for training ESRGAN model."""
+"""Loss functions for training ESRGAN model.
+
+The ESRGAN model makes use of three loss functions: pixel loss, perceptual
+loss(vgg_loss) and adversarial loss. Adversarial loss for the model is
+calculated using relativistic average loss which is pre-defined in TF-GAN.
+"""
 
 import tensorflow as tf
 
@@ -31,70 +36,6 @@ def pixel_loss(y_true, y_pred):
   y_true = tf.cast(y_true, tf.float32)
   y_pred = tf.cast(y_pred, tf.float32)
   return tf.reduce_mean(tf.reduce_mean(tf.abs(y_true - y_pred), axis=0))
-
-
-# TODO(nivedwho): Remove this once the relativitic losses are added to TF-GAN.
-def ragan_generator_loss(d_real, d_fake, scope=None):
-  """To calculate the adversarial loss for generator.
-
-  Args:
-    d_real: Discriminator output on real data.
-    d_fake: Discriminator output on generated data. Expected to be in the range
-      of (-inf, inf).
-    scope: The scope for the operations performed in computing the loss.
-
-  Returns:
-    Adversarial loss for generator.
-  """
-  with tf.compat.v1.name_scope(
-      scope, 'relativistic_avg_generator_loss', values=[d_real, d_fake]):
-
-    def get_logits(x, y):
-      return x - tf.reduce_mean(y)
-
-    real_logits = get_logits(d_real, d_fake)
-    fake_logits = get_logits(d_fake, d_real)
-
-    real_loss = tf.reduce_mean(
-        tf.nn.sigmoid_cross_entropy_with_logits(
-            labels=tf.zeros_like(real_logits), logits=real_logits))
-    fake_loss = tf.reduce_mean(
-        tf.nn.sigmoid_cross_entropy_with_logits(
-            labels=tf.ones_like(fake_logits), logits=fake_logits))
-
-  return real_loss + fake_loss
-
-
-# TODO(nivedwho): Remove this once the relativitic losses are added to TF-GAN.
-def ragan_discriminator_loss(d_real, d_fake, scope=None):
-  """To calculate the adversarial loss for discriminator.
-
-  Args:
-    d_real: Discriminator output on real data.
-    d_fake: Discriminator output on generated data. Expected to be in the range
-      of (-inf, inf).
-    scope: The scope for the operations performed in computing the loss.
-
-  Returns:
-    Adversarial loss for discriminator.
-  """
-  with tf.compat.v1.name_scope(
-      scope, 'relativistic_avg_discriminator_loss', values=[d_real, d_fake]):
-
-    def get_logits(x, y):
-      return x - tf.reduce_mean(y)
-
-    real_logits = get_logits(d_real, d_fake)
-    fake_logits = get_logits(d_fake, d_real)
-
-    real_loss = tf.reduce_mean(
-        tf.nn.sigmoid_cross_entropy_with_logits(
-            labels=tf.ones_like(real_logits), logits=real_logits))
-    fake_loss = tf.reduce_mean(
-        tf.nn.sigmoid_cross_entropy_with_logits(
-            labels=tf.zeros_like(fake_logits), logits=fake_logits))
-
-  return real_loss + fake_loss
 
 
 def vgg_loss(weight=None, input_shape=None):

--- a/tensorflow_gan/examples/esrgan/losses_test.py
+++ b/tensorflow_gan/examples/esrgan/losses_test.py
@@ -18,6 +18,8 @@
 from absl.testing import absltest
 
 import tensorflow as tf
+import tensorflow_gan as tfgan
+
 from tensorflow_gan.examples.esrgan import losses
 
 
@@ -32,6 +34,9 @@ class LossesTest(tf.test.TestCase, absltest.TestCase):
     self._discriminator_gen_logits = tf.constant([10.0, 4.4, -5.5, 3.6])
     self._discriminator_real_logits = tf.constant([-2.0, 0.4, 12.5, 2.7])
 
+    self.gen_loss = tfgan.losses.losses_impl.relativistic_generator_loss
+    self.disc_loss = tfgan.losses.losses_impl.relativistic_discriminator_loss
+
     self._expected_pixel_loss = 35.050003
     self._expected_g_loss = 4.9401135
     self._expected_d_loss = 4.390114
@@ -43,10 +48,10 @@ class LossesTest(tf.test.TestCase, absltest.TestCase):
       self.assertNear(self._expected_pixel_loss, sess.run(pixel_loss), 1e-5)
 
   def test_ragan_loss(self):
-    g_loss = losses.ragan_generator_loss(self._discriminator_real_logits,
-                                         self._discriminator_gen_logits)
-    d_loss = losses.ragan_discriminator_loss(self._discriminator_real_logits,
-                                             self._discriminator_gen_logits)
+    g_loss = self.gen_loss(self._discriminator_real_logits,
+                           self._discriminator_gen_logits)
+    d_loss = self.disc_loss(self._discriminator_real_logits,
+                            self._discriminator_gen_logits)
     with self.cached_session() as sess:
       sess.run(tf.compat.v1.global_variables_initializer())
       self.assertNear(self._expected_g_loss, sess.run(g_loss), 1e-5)

--- a/tensorflow_gan/examples/esrgan/train_lib.py
+++ b/tensorflow_gan/examples/esrgan/train_lib.py
@@ -20,6 +20,7 @@ import os
 from absl import logging
 
 import tensorflow as tf
+import tensorflow_gan as tfgan
 
 from tensorflow_gan.examples.esrgan import losses
 from tensorflow_gan.examples.esrgan import networks
@@ -163,10 +164,9 @@ def train_esrgan(hparams, data):
       percep_loss = tf.reduce_mean(perceptual_loss(image_hr, fake))
       l1_loss = losses.pixel_loss(image_hr, fake)
 
-      # TODO(nivedwho): Replace these functions once TF-GAN losses are updated.
-      gen_loss = losses.ragan_generator_loss(
+      gen_loss = tfgan.losses.losses_impl.relativistic_generator_loss(
           discriminator(image_hr), discriminator(fake))
-      disc_loss = losses.ragan_discriminator_loss(
+      disc_loss = tfgan.losses.losses_impl.relativistic_discriminator_loss(
           discriminator(image_hr), discriminator(fake))
 
       gen_loss = percep_loss + hparams.lambda_ * gen_loss + hparams.eta * l1_loss


### PR DESCRIPTION
Replaced relativistic loss functions defined in the ESRGAN example scripts with `relativistic_generator_loss()` and `relativistic_discriminator_loss()` from TF-GAN losses.